### PR TITLE
Ignore fields with 'json:"-"' tag

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"text/template"
@@ -33,13 +34,14 @@ type ExternalImporter struct {
 }
 
 type objectEntry struct {
-	Converter string
-	Field     string
-	JsonField string
-	Type      string
-	Tag       string
-	Default   string
-	Required  bool
+	Converter     string
+	Field         string
+	JsonField     string
+	Type          string
+	Tag           string
+	Default       string
+	Required      bool
+	IgnoredInJSON bool
 }
 
 type object struct {
@@ -323,14 +325,17 @@ func (g *Generator) convertObject(obj *tstypes.Object, upper *metadata) converte
 			importPrefix = ct.ImportAlias + "."
 		}
 
+		ignoredInJSON := reflect.StructTag(e.RawTag).Get("json") == "-"
+
 		converted.Fields = append(converted.Fields, objectEntry{
-			Field:     ReplaceFieldName(e.ObjectEntry.RawName),
-			JsonField: e.name,
-			Converter: importPrefix + ct.Converter,
-			Type:      importPrefix + ct.Type,
-			Tag:       e.RawTag,
-			Default:   ct.Default,
-			Required:  ct.Required,
+			Field:         ReplaceFieldName(e.ObjectEntry.RawName),
+			JsonField:     e.name,
+			Converter:     importPrefix + ct.Converter,
+			Type:          importPrefix + ct.Type,
+			Tag:           e.RawTag,
+			Default:       ct.Default,
+			Required:      ct.Required,
+			IgnoredInJSON: ignoredInJSON,
 		})
 	}
 

--- a/templates/template.dart
+++ b/templates/template.dart
@@ -155,17 +155,17 @@ class {{ $elm.Name }} {
 
   factory {{ $elm.Name }}.fromJson(Map<String, dynamic> json) {
     return {{ $elm.Name }}(
-{{- range $f := $elm.Fields }}
+{{- range $f := $elm.Fields }}{{ if not $f.IgnoredInJSON }}
       {{ $f.Field }}: const {{ if ne $f.Converter "" }}{{ $f.Converter }}.fromJson(json['{{ $f.JsonField }}']){{ else }}json['{{ $f.JsonField }}'] as {{ $f.Type }}{{end}},
-{{- end }}
+{{ end }}{{- end }}
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-{{- range $f := $elm.Fields }}
+{{- range $f := $elm.Fields }}{{ if not $f.IgnoredInJSON }}
       '{{ $f.JsonField }}': const {{ if ne $f.Converter "" }}{{ $f.Converter }}.toJson({{ $f.Field }}){{ else }}{{ $f.Field }}{{end}},
-{{- end }}
+{{- end }}{{ end }}
     };
   }
 }


### PR DESCRIPTION
For go-generaluze/go2dart#260 のため，structには追加するがJSONConverterでは処理しないフィールドに対応する